### PR TITLE
Check negative key in heap_push

### DIFF
--- a/CCDSALG_S22_MartinJavierEleydo-20250727T110158Z-1-001/CCDSALG_S22_MartinJavierEleydo/src/data_structures/heap/heap.c
+++ b/CCDSALG_S22_MartinJavierEleydo-20250727T110158Z-1-001/CCDSALG_S22_MartinJavierEleydo/src/data_structures/heap/heap.c
@@ -90,6 +90,7 @@ static bool grow(Heap *h)
 size_t heap_push(Heap *h, void *item, int key)
 {
     if (!h) return SIZE_MAX;
+    if (key < 0) return SIZE_MAX;  /* enforce non-negative priorities */
     if (h->size == h->cap && !grow(h)) return SIZE_MAX;
     size_t idx = h->size++;
     h->key[idx]  = key;

--- a/CCDSALG_S22_MartinJavierEleydo-20250727T110158Z-1-001/CCDSALG_S22_MartinJavierEleydo/test/test_heap_neg.c
+++ b/CCDSALG_S22_MartinJavierEleydo-20250727T110158Z-1-001/CCDSALG_S22_MartinJavierEleydo/test/test_heap_neg.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "heap.h"
+
+int main(void) {
+    Heap *h = heap_create(4);
+    if (!h) {
+        fprintf(stderr, "create failed\n");
+        return 1;
+    }
+    if (heap_push(h, NULL, -1) != SIZE_MAX) {
+        fprintf(stderr, "negative key accepted\n");
+        return 1;
+    }
+    heap_destroy(h);
+    printf("neg-key test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- prevent negative priorities in `heap_push`
- create a dedicated test ensuring a negative key is rejected

## Testing
- `gcc -Wall -Wextra -pedantic -std=c11 -Isrc/data_structures/heap test/test_heap_neg.c src/data_structures/heap/heap.c -o test/test_heap_neg && ./test/test_heap_neg`
- `gcc -Wall -Wextra -pedantic -std=c11 -Isrc/data_structures/heap test/test_heap.c src/data_structures/heap/heap.c -o test/test_heap && ./test/test_heap` (fails: `heap_extract_min(h, &key) != NULL`)


------
https://chatgpt.com/codex/tasks/task_e_68860b37ed048328b9925b8e3b455cfd